### PR TITLE
Add additional extensions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
         .library(name: "XCTExtensions", targets: ["XCTExtensions"]),
         .library(name: "DebugExtensions", targets: ["DebugExtensions"]),
         .library(name: "CocoaExtensions", targets: ["CocoaExtensions"]),
+        .library(name: "CrossPlatformExtensions", targets: ["CrossPlatformExtensions"])
     ],
     dependencies: [
         .package(url: "https://github.com/screensailor/Periscope.git", from: "0.1.0"),
@@ -31,13 +32,14 @@ let package = Package(
         .package(url: "https://github.com/screensailor/Peek.git", from: "0.1.0"),
     ],
     targets: [
-        .target(name: "ThousandExtensions", dependencies: ["FoundationExtensions", "SKExtensions", "Periscope", "CocoaExtensions"]),
+        .target(name: "ThousandExtensions", dependencies: ["FoundationExtensions", "SKExtensions", "Periscope", "CocoaExtensions", "CrossPlatformExtensions"]),
         .target(name: "SKExtensions", dependencies: ["FoundationExtensions"]),
         .target(name: "FoundationExtensions", dependencies: ["CGExtensions"]),
         .target(name: "CGExtensions", dependencies: ["SwiftExtensions", "Space", "Drawing"]),
         .target(name: "SwiftExtensions", dependencies: ["DebugExtensions", "TrySwitch", "DictionaryArithmetic", "KeyPathArithmetic"]),
         .target(name: "XCTExtensions", dependencies: ["DebugExtensions", "Hope", "TrySwitch"]),
         .target(name: "DebugExtensions", dependencies: ["Peek"]),
-        .target(name: "CocoaExtensions")
+        .target(name: "CocoaExtensions"),
+        .target(name: "CrossPlatformExtensions")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
         .library(name: "SwiftExtensions", targets: ["SwiftExtensions"]),
         .library(name: "XCTExtensions", targets: ["XCTExtensions"]),
         .library(name: "DebugExtensions", targets: ["DebugExtensions"]),
+        .library(name: "CocoaExtensions", targets: ["CocoaExtensions"]),
     ],
     dependencies: [
         .package(url: "https://github.com/screensailor/Periscope.git", from: "0.1.0"),
@@ -30,12 +31,13 @@ let package = Package(
         .package(url: "https://github.com/screensailor/Peek.git", from: "0.1.0"),
     ],
     targets: [
-        .target(name: "ThousandExtensions", dependencies: ["FoundationExtensions", "SKExtensions", "Periscope"]),
+        .target(name: "ThousandExtensions", dependencies: ["FoundationExtensions", "SKExtensions", "Periscope", "CocoaExtensions"]),
         .target(name: "SKExtensions", dependencies: ["FoundationExtensions"]),
         .target(name: "FoundationExtensions", dependencies: ["CGExtensions"]),
         .target(name: "CGExtensions", dependencies: ["SwiftExtensions", "Space", "Drawing"]),
         .target(name: "SwiftExtensions", dependencies: ["DebugExtensions", "TrySwitch", "DictionaryArithmetic", "KeyPathArithmetic"]),
         .target(name: "XCTExtensions", dependencies: ["DebugExtensions", "Hope", "TrySwitch"]),
         .target(name: "DebugExtensions", dependencies: ["Peek"]),
+        .target(name: "CocoaExtensions")
     ]
 )

--- a/Sources/CocoaExtensions/NSControl.swift
+++ b/Sources/CocoaExtensions/NSControl.swift
@@ -1,3 +1,4 @@
+#if canImport(Cocoa)
 import Cocoa
 
 extension NSControl {
@@ -6,3 +7,4 @@ extension NSControl {
         self.action = action
     }
 }
+#endif

--- a/Sources/CocoaExtensions/NSControl.swift
+++ b/Sources/CocoaExtensions/NSControl.swift
@@ -1,0 +1,8 @@
+import Cocoa
+
+extension NSControl {
+    public func addTarget(_ target: AnyObject, action: Selector) {
+        self.target = target
+        self.action = action
+    }
+}

--- a/Sources/CrossPlatformExtensions/typealiases.swift
+++ b/Sources/CrossPlatformExtensions/typealiases.swift
@@ -1,0 +1,13 @@
+#if canImport(Cocoa)
+import Cocoa
+#elseif canImport(UIKit)
+import UIKit
+#elseif canImport(SwiftUI)
+import SwiftUI
+#endif
+
+#if canImport(Cocoa)
+public typealias Window = NSWindow
+#elseif canImport(UIKit)
+public typealias Window = UIWindow
+#endif

--- a/Sources/CrossPlatformExtensions/typealiases.swift
+++ b/Sources/CrossPlatformExtensions/typealiases.swift
@@ -2,7 +2,9 @@
 import Cocoa
 #elseif canImport(UIKit)
 import UIKit
-#elseif canImport(SwiftUI)
+#endif
+
+#if canImport(SwiftUI)
 import SwiftUI
 #endif
 
@@ -10,4 +12,10 @@ import SwiftUI
 public typealias Window = NSWindow
 #elseif canImport(UIKit)
 public typealias Window = UIWindow
+#endif
+
+#if os(macOS)
+public typealias ViewRepresentable = NSViewRepresentable
+#elseif os(iOS)
+public typealias ViewRepresentable = UIViewRepresentable
 #endif

--- a/Sources/FoundationExtensions/URL.swift
+++ b/Sources/FoundationExtensions/URL.swift
@@ -14,3 +14,9 @@ extension URL {
         return components.queryItems?.first(where: { $0.name == queryParam })?.value
     }
 }
+
+extension String {
+    public var url: URL? {
+        return URL(string: self)
+    }
+}

--- a/Sources/FoundationExtensions/URL.swift
+++ b/Sources/FoundationExtensions/URL.swift
@@ -6,4 +6,11 @@ extension URL {
         o.appendPathExtension(ext)
         return o
     }
+    
+    public subscript(queryParam: String) -> String? {
+        guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false)
+            else { return nil }
+        
+        return components.queryItems?.first(where: { $0.name == queryParam })?.value
+    }
 }

--- a/Sources/FoundationExtensions/URL.swift
+++ b/Sources/FoundationExtensions/URL.swift
@@ -6,13 +6,6 @@ extension URL {
         o.appendPathExtension(ext)
         return o
     }
-    
-    public subscript(queryParam: String) -> String? {
-        guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false)
-            else { return nil }
-        
-        return components.queryItems?.first(where: { $0.name == queryParam })?.value
-    }
 }
 
 extension String {

--- a/Sources/SwiftExtensions/String.swift
+++ b/Sources/SwiftExtensions/String.swift
@@ -3,8 +3,4 @@ extension String {
     public static func * (l: String, r: Int) -> String {
         repeatElement(l, count: r).joined()
     }
-    
-    public func titlecase() -> String {
-      return prefix(1).uppercased() + lowercased().dropFirst()
-    }
 }

--- a/Sources/SwiftExtensions/String.swift
+++ b/Sources/SwiftExtensions/String.swift
@@ -7,8 +7,4 @@ extension String {
     public func titlecase() -> String {
       return prefix(1).uppercased() + lowercased().dropFirst()
     }
-
-    public mutating func titlecase() {
-      self = titlecase()
-    }
 }

--- a/Sources/SwiftExtensions/String.swift
+++ b/Sources/SwiftExtensions/String.swift
@@ -3,4 +3,12 @@ extension String {
     public static func * (l: String, r: Int) -> String {
         repeatElement(l, count: r).joined()
     }
+    
+    public func titlecase() -> String {
+      return prefix(1).uppercased() + lowercased().dropFirst()
+    }
+
+    public mutating func titlecase() {
+      self = titlecase()
+    }
 }

--- a/Sources/ThousandExtensions/ThousandExtensions.swift
+++ b/Sources/ThousandExtensions/ThousandExtensions.swift
@@ -2,6 +2,7 @@
 @_exported import SKExtensions
 @_exported import Periscope
 @_exported import TrySwitch
+@_exported import CrossPlatformExtensions
 
 #if canImport(Cocoa)
 @_exported import CocoaExtensions

--- a/Sources/ThousandExtensions/ThousandExtensions.swift
+++ b/Sources/ThousandExtensions/ThousandExtensions.swift
@@ -3,6 +3,10 @@
 @_exported import Periscope
 @_exported import TrySwitch
 
+#if canImport(Cocoa)
+@_exported import CocoaExtensions
+#endif
+
 // TrySwitch
 infix operator ?= : AssignmentPrecedence
 


### PR DESCRIPTION
### URL.swift
Add extension to make `URL` from `String`
```swift
let url = "https://example.com?value=test".url!
url.self // URL
```

### NSControl.swift
A new target `CocoaExtensions` that is only exported if `Cocoa` can be imported.
Adds helper function to set target & action in one call slightly resembling `UIKit` target/action.
```swift
#if os(macOS)
addTarget(self, action: #selector(clicked))
#elseif os(iOS)
addTarget(self, action: #selector(clicked), for: .touchUpInside)
#endif
```

### typealiases.swift
A new target `CrossPlatformExtensions` to hold extensions that it's focus is to abstract work across platforms.
```swift
#if canImport(Cocoa)
public typealias Window = NSWindow
#elseif canImport(UIKit)
public typealias Window = UIWindow
#endif

#if os(macOS)
public typealias ViewRepresentable = NSViewRepresentable
#elseif os(iOS)
public typealias ViewRepresentable = UIViewRepresentable
#endif
```