### PR TITLE
Add extensions for recursively applying values to a sequence of functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+# SwiftPM
+
+.swiftpm

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,88 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "DictionaryArithmetic",
+        "repositoryURL": "https://github.com/screensailor/DictionaryArithmetic.git",
+        "state": {
+          "branch": null,
+          "revision": "1a5407828f57d9b9f88b69591af9f5b5a3522f21",
+          "version": "0.1.0"
+        }
+      },
+      {
+        "package": "Drawing",
+        "repositoryURL": "https://github.com/screensailor/Drawing.git",
+        "state": {
+          "branch": null,
+          "revision": "1f27ac0cdda594cd8cdd45441f119b98e0d1d4cb",
+          "version": "0.1.0"
+        }
+      },
+      {
+        "package": "Hope",
+        "repositoryURL": "https://github.com/screensailor/Hope.git",
+        "state": {
+          "branch": null,
+          "revision": "0ac73cd24da586a2669e5fc426fd0dc7f8e36b7c",
+          "version": "0.1.0"
+        }
+      },
+      {
+        "package": "KeyPathArithmetic",
+        "repositoryURL": "https://github.com/screensailor/KeyPathArithmetic.git",
+        "state": {
+          "branch": null,
+          "revision": "a8fdf6cf0fe72a39a5e2d7e8c899b9a53807efc8",
+          "version": "0.1.0"
+        }
+      },
+      {
+        "package": "Peek",
+        "repositoryURL": "https://github.com/screensailor/Peek.git",
+        "state": {
+          "branch": null,
+          "revision": "bd3acb07b5208c123453ec604dc0161413cf2dd5",
+          "version": "0.1.0"
+        }
+      },
+      {
+        "package": "Periscope",
+        "repositoryURL": "https://github.com/screensailor/Periscope.git",
+        "state": {
+          "branch": null,
+          "revision": "d3442938b434ef1ffc7ef513ff5e0cbc205462a7",
+          "version": "0.1.0"
+        }
+      },
+      {
+        "package": "Space",
+        "repositoryURL": "https://github.com/screensailor/Space.git",
+        "state": {
+          "branch": null,
+          "revision": "d50d98c200f74d60407a58c5008033facbc49b46",
+          "version": "0.1.1"
+        }
+      },
+      {
+        "package": "swift-numerics",
+        "repositoryURL": "https://github.com/apple/swift-numerics.git",
+        "state": {
+          "branch": null,
+          "revision": "5dfc460876510988560170cee3702ab01b89587a",
+          "version": "0.0.5"
+        }
+      },
+      {
+        "package": "TrySwitch",
+        "repositoryURL": "https://github.com/screensailor/TrySwitch.git",
+        "state": {
+          "branch": null,
+          "revision": "68ac7d1532a199b31a2b171661b9a13a4b5d2c8f",
+          "version": "0.1.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Sources/SwiftExtensions/Sequence.swift
+++ b/Sources/SwiftExtensions/Sequence.swift
@@ -74,19 +74,19 @@ extension Sequence {
     
     // TODO: Redefine this when KeyPath for instance functions lands: https://forums.swift.org/t/allow-key-paths-to-reference-unapplied-instance-methods/35582
     // func map<Value>(_ value: Value, over: KeyPath<Element, (Value) -> Value>) -> [Value] {
-    @inlinable public func map<Value>(using: (Element) -> (Value) -> Value, startingWith value: Value) -> [Value]  {
+    @inlinable public func map<A>(using: (Element) -> (A) -> A, startingWith value: A) -> [A]  {
         SwiftExtensions.map(over: map(using), startingWith: value)
     }
     
-    @inlinable public func mapped<A>(startingWith value: A) -> [A] where Element == (A) -> A {
+    @inlinable public func map<A>(startingWith value: A) -> [A] where Element == (A) -> A {
         SwiftExtensions.map(over: self, startingWith: value)
     }
     
-    @inlinable @inlinable func reduce<Value>(_ value: Value, over: (Element) -> (Value) -> Value) -> Value {
+    @inlinable public func reduce<A>(_ value: A, over: (Element) -> (A) -> A) -> A {
         SwiftExtensions.reduce(over: map(over), startingWith: value)
     }
     
-    @inlinable public func reduced<A>(startingWith value: A) -> A where Element == (A) -> A {
+    @inlinable public func reduce<A>(startingWith value: A) -> A where Element == (A) -> A {
         SwiftExtensions.reduce(over: self, startingWith: value)
     }
     

--- a/Sources/SwiftExtensions/Sequence.swift
+++ b/Sources/SwiftExtensions/Sequence.swift
@@ -72,34 +72,16 @@ extension Collection where Element: ExpressibleByDictionaryLiteral {
 
 extension Sequence {
     
-    // TODO: Redefine this when KeyPath for instance functions lands: https://forums.swift.org/t/allow-key-paths-to-reference-unapplied-instance-methods/35582
-    // func map<Value>(_ value: Value, over: KeyPath<Element, (Value) -> Value>) -> [Value] {
-    @inlinable public func map<A>(using: (Element) -> (A) -> A, startingWith value: A) -> [A]  {
-        SwiftExtensions.map(over: map(using), startingWith: value)
+    public func map<A>(byPiping value: A) -> [A] where Element == (A) -> A {
+        var current = value
+        return map { ƒ in
+            current = ƒ(current)
+            return current
+        }
     }
-    
-    @inlinable public func map<A>(startingWith value: A) -> [A] where Element == (A) -> A {
-        SwiftExtensions.map(over: self, startingWith: value)
-    }
-    
-    @inlinable public func reduce<A>(_ value: A, over: (Element) -> (A) -> A) -> A {
-        SwiftExtensions.reduce(over: map(over), startingWith: value)
-    }
-    
-    @inlinable public func reduce<A>(startingWith value: A) -> A where Element == (A) -> A {
-        SwiftExtensions.reduce(over: self, startingWith: value)
-    }
-    
-}
 
-public func map<A, Functions>(over functions: Functions, startingWith value: A) -> [A] where Functions: Sequence, Functions.Element == (A) -> A {
-    var current = value
-    return functions.map { ƒ in
-        current = ƒ(current)
-        return current
+    public func reduce<A>(byPiping value: A) -> A where Element == (A) -> A {
+        reduce(value) { $1($0) }
     }
-}
-
-public func reduce<A, Functions>(over functions: Functions, startingWith value: A) -> A where Functions: Sequence, Functions.Element == (A) -> A {
-    functions.reduce(value) { $1($0) }
+    
 }

--- a/Sources/SwiftExtensions/Sequence.swift
+++ b/Sources/SwiftExtensions/Sequence.swift
@@ -69,3 +69,37 @@ extension Collection where Element: ExpressibleByDictionaryLiteral {
         return try dropFirst().reduce(first, nextPartialResult)
     }
 }
+
+extension Sequence {
+    
+    // TODO: Redefine this when KeyPath for instance functions lands: https://forums.swift.org/t/allow-key-paths-to-reference-unapplied-instance-methods/35582
+    // func map<Value>(_ value: Value, over: KeyPath<Element, (Value) -> Value>) -> [Value] {
+    @inlinable public func map<Value>(using: (Element) -> (Value) -> Value, startingWith value: Value) -> [Value]  {
+        SwiftExtensions.map(over: map(using), startingWith: value)
+    }
+    
+    @inlinable public func mapped<A>(startingWith value: A) -> [A] where Element == (A) -> A {
+        SwiftExtensions.map(over: self, startingWith: value)
+    }
+    
+    @inlinable @inlinable func reduce<Value>(_ value: Value, over: (Element) -> (Value) -> Value) -> Value {
+        SwiftExtensions.reduce(over: map(over), startingWith: value)
+    }
+    
+    @inlinable public func reduced<A>(startingWith value: A) -> A where Element == (A) -> A {
+        SwiftExtensions.reduce(over: self, startingWith: value)
+    }
+    
+}
+
+public func map<A, Functions>(over functions: Functions, startingWith value: A) -> [A] where Functions: Sequence, Functions.Element == (A) -> A {
+    var current = value
+    return functions.map { ƒ in
+        current = ƒ(current)
+        return current
+    }
+}
+
+public func reduce<A, Functions>(over functions: Functions, startingWith value: A) -> A where Functions: Sequence, Functions.Element == (A) -> A {
+    functions.reduce(value) { $1($0) }
+}


### PR DESCRIPTION
Introduce new API on sequence to allow iterated mapping of function values seeded with an initial value. 

```swift
extension Sequence {
    @inlinable public func map<A>(using: (Element) -> (A) -> A, startingWith value: A) -> [A]
    @inlinable public func map<A>(startingWith value: A) -> [A] where Self.Element == (A) -> A
    @inlinable public func reduce<A>(_ value: A, over: (Element) -> (A) -> A) -> A
    @inlinable public func reduce<A>(startingWith value: A) -> A where Self.Element == (A) -> A
}
public func map<A, Functions>(over functions: Functions, startingWith value: A) -> [A] where Functions : Sequence, Functions.Element == (A) -> A
public func reduce<A, Functions>(over functions: Functions, startingWith value: A) -> A where Functions : Sequence, Functions.Element == (A) -> A
```

It's currently being used in MirrorMirror to traverse the reflections:

```swift
mirrors.map(using: SKRelativeLineSegment.reflect, startingWith: start)
```

Two new top-level functions `map` and `reduce` are introduced which allow for compose the different API's available on the sequence extension since I am not able to specify a constraint on Element of Sequence bound to `(A) -> A`.

For the performance I tested different implementations for the `map` function.

### map_reduce
```swift
public func map_reduce<A, Functions>(over functions: Functions, startingWith value: A) -> [A] where Functions: Collection, Functions.Element == (A) -> A {
    var result = [A]()
    result.reserveCapacity(functions.count)
    return functions.reduce(into: (value: value, array: result)) { a, ƒ in
        a.value = ƒ(a.value)
        a.array.append(a.value)
    }.array
}
```

### map_for_in
```swift
public func map_for_in<A, Functions>(over functions: Functions, startingWith value: A) -> [A] where Functions: Collection, Functions.Element == (A) -> A {
    var result = [A]()
    result.reserveCapacity(functions.count)
    var current = value
    for ƒ in functions {
        current = ƒ(current)
        result.append(current)
    }
    return result
}
```

### map_map
```swift
public func map_map<A, Functions>(over functions: Functions, startingWith value: A) -> [A] where Functions: Sequence, Functions.Element == (A) -> A {
    var current = value
    return functions.map { ƒ in
        current = ƒ(current)
        return current
    }
}
```

![image](https://user-images.githubusercontent.com/1382565/82474777-762a3800-9ac3-11ea-87be-b2c6ccafea68.png)

I decided to go with map because it out-performed the other variants as well as still allowing `lazy` to work correctly (is that's what you want).

```swift
mirrors.lazy.map(SKRelativeLineSegment.reflect).map(startingWith: start)
```